### PR TITLE
fix: code snippets need language names

### DIFF
--- a/pkg/cmd/generate/snippets/snippets.go
+++ b/pkg/cmd/generate/snippets/snippets.go
@@ -75,7 +75,7 @@ func generateMarkdownSnippet(snippet map[string]string) string {
 	languages := sortLanguages(snippet)
 
 	for _, lang := range languages {
-		result += fmt.Sprintf("\n```%s\n", lang)
+		result += fmt.Sprintf("\n```%s %s\n", lang, utils.GetLanguageName(lang))
 		result += snippet[lang]
 		result += "\n```\n"
 	}

--- a/pkg/cmd/generate/snippets/snippets_test.go
+++ b/pkg/cmd/generate/snippets/snippets_test.go
@@ -131,7 +131,7 @@ func TestGenerateMarkdownSnippet(t *testing.T) { //nolint:funlen
 				"go": `fmt.Println("hello")`,
 			},
 			want: "<CodeGroup>\n\n" +
-				"```go\n" +
+				"```go Go\n" +
 				"fmt.Println(\"hello\")\n" +
 				"```\n\n" +
 				"</CodeGroup>",
@@ -139,14 +139,14 @@ func TestGenerateMarkdownSnippet(t *testing.T) { //nolint:funlen
 		{
 			name: "two languages unsorted input",
 			snippet: map[string]string{
-				"py": `print("hi")`,
-				"go": `fmt.Println("hi")`,
+				"python": `print("hi")`,
+				"go":     `fmt.Println("hi")`,
 			},
 			want: "<CodeGroup>\n\n" +
-				"```go\n" +
+				"```go Go\n" +
 				"fmt.Println(\"hi\")\n" +
 				"```\n\n" +
-				"```py\n" +
+				"```python Python\n" +
 				"print(\"hi\")\n" +
 				"```\n\n" +
 				"</CodeGroup>",
@@ -159,13 +159,13 @@ func TestGenerateMarkdownSnippet(t *testing.T) { //nolint:funlen
 				"go":   `fmt.Println("hey")`,
 			},
 			want: "<CodeGroup>\n\n" +
-				"```go\n" +
+				"```go Go\n" +
 				"fmt.Println(\"hey\")\n" +
 				"```\n\n" +
-				"```js\n" +
+				"```js JavaScript\n" +
 				"console.log(\"hey\")\n" +
 				"```\n\n" +
-				"```ruby\n" +
+				"```ruby Ruby\n" +
 				"puts \"hey\"\n" +
 				"```\n\n" +
 				"</CodeGroup>",

--- a/pkg/dictionary/dictionary.go
+++ b/pkg/dictionary/dictionary.go
@@ -4,7 +4,10 @@ package dictionary
 var dictionary = map[string]string{
 	"csharp":     "C#",
 	"javascript": "JavaScript",
+	"js":         "JavaScript",
 	"php":        "PHP",
+	"ts":         "TypeScript",
+	"typescript": "TypeScript",
 }
 
 // Translate returns the translated string if it's present in the dictionary, the original otherwise.


### PR DESCRIPTION
For `<CodeGroup>` code snippets, we'll also need the label for the tabs.