### PR TITLE
fix: method names should be kebab case

### DIFF
--- a/pkg/cmd/generate/snippets/snippets.go
+++ b/pkg/cmd/generate/snippets/snippets.go
@@ -58,7 +58,7 @@ func runCommand(opts *Options) {
 	for snippet, examples := range rawSnippets {
 		for name, example := range examples {
 			err := writeSnippet(
-				filepath.Join(opts.OutputDirectory, snippet),
+				filepath.Join(opts.OutputDirectory, utils.ToKebabCase(snippet)),
 				fmt.Sprintf("%s.mdx", utils.ToCamelCase(name)),
 				generateMarkdownSnippet(example),
 			)


### PR DESCRIPTION
Only parameter names and examples should be camel case.