### PR TITLE
fix: SLA page template

### DIFF
--- a/pkg/cmd/generate/sla/page.mdx.tmpl
+++ b/pkg/cmd/generate/sla/page.mdx.tmpl
@@ -1,7 +1,8 @@
 ---
 title: Algolia API clients versions
 sidebarTitle: Library versions
-description: List of versions of the Algolia API clients and their support status.
+description: List of versions of the Algolia API clients and their SLA status.
+mode: wide
 ---
 
 Versions of the API clients not listed on this page aren't covered by the [Algolia Service Level Agreement (SLA)](https://www.algolia.com/policies/sla).


### PR DESCRIPTION
Use the 'wide' page mode and change the description for the SLA status page.