### PR TITLE
fix: SLA template

### DIFF
--- a/pkg/cmd/generate/sla/page.mdx.tmpl
+++ b/pkg/cmd/generate/sla/page.mdx.tmpl
@@ -1,5 +1,5 @@
 ---
-title: Algolia API clients versions
+title: Algolia API client versions
 sidebarTitle: Library versions
 description: See which versions of Algolia's API clients are covered by SLA.
 ---
@@ -10,12 +10,12 @@ Versions of the API clients not listed on this page aren't covered by the [Algol
 {{ range . }}
 <Tab title="{{ getLanguageName .Language }}">
 
-<table className="w-full">
+<table>
 <thead>
 <tr>
-<th className="max-w-[33%] w-full">Version</th>
-<th className="max-w-[33%] w-full">Release date</th>
-<th className="max-w-[33%] w-full">SLA status</th>
+<th>Version</th>
+<th>Release date</th>
+<th>SLA status</th>
 </tr>
 </thead>
 <tbody>

--- a/pkg/cmd/generate/sla/sla.go
+++ b/pkg/cmd/generate/sla/sla.go
@@ -64,9 +64,10 @@ func NewSlaCommand() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&opts.Output, "output", "o", "", "Output file")
 	cmd.Flags().
-		StringVarP(&opts.VersionsFile, "versions", "v", "", "Generate file with latest versions")
+		StringVarP(&opts.Output, "output", "o", "", "MDX file for listing the supported versions.")
+	cmd.Flags().
+		StringVar(&opts.VersionsFile, "versions-snippets-file", "", "Generate snippets file for referencing version numbers")
 
 	return cmd
 }


### PR DESCRIPTION
Fix the name of the versions page template and rename the `--versions-snippets-file` option so that it's clearer.