### PR TITLE
fix: strip markdown and quote short descriptions

### DIFF
--- a/pkg/cmd/generate/clients/clients.go
+++ b/pkg/cmd/generate/clients/clients.go
@@ -140,7 +140,8 @@ func runCommand(opts *Options, printer *output.Printer) error {
 	printer.Verbosef("Spec %s has %d operations.\n", opts.InputFilename, len(opData))
 
 	tmpl := template.Must(template.New("method").Funcs(template.FuncMap{
-		"trim": strings.TrimSpace,
+		"frontmatterString": utils.QuoteFrontmatterString,
+		"trim":              strings.TrimSpace,
 	}).Parse(methodTemplate))
 
 	if err := writeAPIData(opData, tmpl, printer); err != nil {
@@ -181,6 +182,7 @@ func getAPIData(
 			}
 
 			short, long := utils.SplitDescription(op.Description)
+			short = utils.StripMarkdown(short)
 
 			data := OperationData{
 				ACL:              utils.AclToString(acl),

--- a/pkg/cmd/generate/clients/clients_test.go
+++ b/pkg/cmd/generate/clients/clients_test.go
@@ -1,0 +1,123 @@
+package clients
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"text/template"
+
+	"github.com/algolia/docli/pkg/cmd/generate/utils"
+	"go.yaml.in/yaml/v4"
+)
+
+func TestGetAPIDataRendersQuotedPlainTextDescription(t *testing.T) {
+	t.Parallel()
+
+	spec := []byte(`openapi: 3.0.0
+info:
+  title: Search API
+  version: 1.0.0
+paths:
+  /1/keys/{key}:
+    get:
+      operationId: getApiKey
+      summary: Get an API key
+      description: |
+        Use the [API key](https://algolia.com) endpoint with **filters:active**.
+
+        This body keeps [markdown](https://algolia.com/doc) and **details** intact.
+      x-acl:
+        - search
+`)
+
+	doc, err := utils.LoadSpec(spec)
+	if err != nil {
+		t.Fatalf("LoadSpec() error = %v", err)
+	}
+
+	data, err := getAPIData(doc, &Options{
+		APIName:         "search",
+		InputFilename:   "specs/search.yml",
+		OutputDirectory: "out",
+	})
+	if err != nil {
+		t.Fatalf("getAPIData() error = %v", err)
+	}
+
+	if len(data) != 1 {
+		t.Fatalf("getAPIData() len = %d, want 1", len(data))
+	}
+
+	if got := data[0].ShortDescription; got != "Use the API key endpoint with filters:active." {
+		t.Fatalf(
+			"ShortDescription = %q, want %q",
+			got,
+			"Use the API key endpoint with filters:active.",
+		)
+	}
+
+	if got := data[0].Description; got != "This body keeps [markdown](https://algolia.com/doc) and **details** intact." {
+		t.Fatalf(
+			"Description = %q, want %q",
+			got,
+			"This body keeps [markdown](https://algolia.com/doc) and **details** intact.",
+		)
+	}
+
+	tmpl := template.Must(template.New("method").Funcs(template.FuncMap{
+		"frontmatterString": utils.QuoteFrontmatterString,
+		"trim":              strings.TrimSpace,
+	}).Parse(methodTemplate))
+
+	var rendered bytes.Buffer
+	if err := tmpl.Execute(&rendered, data[0]); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	frontmatter := parseFrontmatter(t, rendered.String())
+	assertFrontmatterDescription(t, frontmatter, "Use the API key endpoint with filters:active.")
+
+	assertRenderedContains(t, rendered.String(), []string{
+		`description: "Use the API key endpoint with filters:active."`,
+		"This body keeps [markdown](https://algolia.com/doc) and **details** intact.",
+		"**Required ACL:** `search`",
+	})
+}
+
+func parseFrontmatter(t *testing.T, rendered string) map[string]any {
+	t.Helper()
+
+	parts := strings.SplitN(rendered, "---\n", 3)
+	if len(parts) < 3 || parts[0] != "" {
+		t.Fatalf("rendered output missing frontmatter:\n%s", rendered)
+	}
+
+	frontmatter := strings.TrimSuffix(parts[1], "\n")
+
+	var parsed map[string]any
+
+	if err := yaml.Unmarshal([]byte(frontmatter), &parsed); err != nil {
+		t.Fatalf("yaml.Unmarshal() error = %v\nfrontmatter:\n%s", err, frontmatter)
+	}
+
+	return parsed
+}
+
+func assertFrontmatterDescription(t *testing.T, frontmatter map[string]any, want string) {
+	t.Helper()
+
+	gotDescription, ok := frontmatter["description"].(string)
+	if !ok || gotDescription != want {
+		t.Fatalf("frontmatter description = %#v, want %q", frontmatter["description"], want)
+	}
+}
+
+func assertRenderedContains(t *testing.T, rendered string, wants []string) {
+	t.Helper()
+
+	for _, want := range wants {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("rendered method missing %q:\n%s", want, rendered)
+		}
+	}
+}

--- a/pkg/cmd/generate/clients/method.mdx.tmpl
+++ b/pkg/cmd/generate/clients/method.mdx.tmpl
@@ -1,6 +1,6 @@
 ---
 title: {{ .Summary }}
-description: {{ .ShortDescription }}
+description: {{ frontmatterString .ShortDescription }}
 public: true
 ---
 {{- if .Deprecated }}

--- a/pkg/cmd/generate/openapi/openapi.go
+++ b/pkg/cmd/generate/openapi/openapi.go
@@ -128,7 +128,9 @@ func runCommand(opts *Options, printer *output.Printer) error {
 		return fmt.Errorf("build overview data for %s: %w", opts.InputFileName, err)
 	}
 
-	ovTmpl := template.Must(template.New("overview").Parse(overviewTemplate))
+	ovTmpl := template.Must(template.New("overview").Funcs(template.FuncMap{
+		"frontmatterString": utils.QuoteFrontmatterString,
+	}).Parse(overviewTemplate))
 
 	err = writeOverviewData(overviewData, ovTmpl, printer)
 	if err != nil {
@@ -142,7 +144,9 @@ func runCommand(opts *Options, printer *output.Printer) error {
 
 	printer.Verbosef("Spec %s has %d operations.\n", opts.InputFileName, len(opData))
 
-	tmpl := template.Must(template.New("stub").Parse(stubTemplate))
+	tmpl := template.Must(template.New("stub").Funcs(template.FuncMap{
+		"frontmatterString": utils.QuoteFrontmatterString,
+	}).Parse(stubTemplate))
 
 	err = writeAPIData(opData, tmpl, printer)
 	if err != nil {
@@ -158,12 +162,18 @@ func getAPIOverviewData(
 	opts *Options,
 ) (OverviewData, error) {
 	result := OverviewData{
-		OutputFilename:   fmt.Sprintf("%s.mdx", opts.APIName),
-		OutputPath:       opts.OutputDirectory,
-		Title:            doc.Model.Info.Title,
-		ShortDescription: doc.Model.Info.Summary,
-		Description:      doc.Model.Info.Description,
+		OutputFilename: fmt.Sprintf("%s.mdx", opts.APIName),
+		OutputPath:     opts.OutputDirectory,
+		Title:          doc.Model.Info.Title,
+		Description:    strings.TrimSpace(doc.Model.Info.Description),
 	}
+
+	short := strings.TrimSpace(doc.Model.Info.Summary)
+	if short == "" {
+		short, result.Description = utils.SplitDescription(doc.Model.Info.Description)
+	}
+
+	result.ShortDescription = utils.StripMarkdown(short)
 
 	return result, nil
 }
@@ -189,40 +199,9 @@ func getAPIData(
 		pathItem := pathPairs.Value()
 
 		for opPairs := pathItem.GetOperations().First(); opPairs != nil; opPairs = opPairs.Next() {
-			op := opPairs.Value()
-
-			short, long := utils.SplitDescription(op.Description)
-
-			acl, err := utils.GetACL(op)
+			data, err := buildOperationData(opPairs.Key(), pathName, opPairs.Value(), opts, prefix)
 			if err != nil {
-				return nil, fmt.Errorf("get ACL for %s %s: %w", opPairs.Key(), pathName, err)
-			}
-
-			data := OperationData{
-				ACL:              utils.AclToString(acl),
-				APIPath:          pathName,
-				Description:      long,
-				InputFilename:    normalizePath(opts.InputFileName),
-				OutputFilename:   utils.GetOutputFilename(op),
-				OutputPath:       prefix,
-				RequiresAdmin:    false,
-				ShortDescription: short,
-				Title:            strings.TrimSpace(op.Summary),
-				Verb:             opPairs.Key(),
-			}
-
-			if data.ACL == "`admin`" {
-				data.RequiresAdmin = true
-			}
-
-			if op.ExternalDocs != nil {
-				desc := strings.TrimSpace(op.ExternalDocs.Description)
-				data.ExternalDocs.Description = strings.TrimSuffix(desc, ".")
-				data.ExternalDocs.URL = op.ExternalDocs.URL
-			}
-
-			if data.ExternalDocs.Description != "" && data.ExternalDocs.URL != "" {
-				data.SeeAlso = true
+				return nil, err
 			}
 
 			result = append(result, data)
@@ -231,6 +210,47 @@ func getAPIData(
 	}
 
 	return result, nil
+}
+
+func buildOperationData(
+	verb, pathName string,
+	op *v3.Operation,
+	opts *Options,
+	prefix string,
+) (OperationData, error) {
+	short, long := utils.SplitDescription(op.Description)
+
+	acl, err := utils.GetACL(op)
+	if err != nil {
+		return OperationData{}, fmt.Errorf("get ACL for %s %s: %w", verb, pathName, err)
+	}
+
+	data := OperationData{
+		ACL:              utils.AclToString(acl),
+		APIPath:          pathName,
+		Description:      long,
+		InputFilename:    normalizePath(opts.InputFileName),
+		OutputFilename:   utils.GetOutputFilename(op),
+		OutputPath:       prefix,
+		RequiresAdmin:    false,
+		ShortDescription: utils.StripMarkdown(short),
+		Title:            strings.TrimSpace(op.Summary),
+		Verb:             verb,
+	}
+
+	if data.ACL == "`admin`" {
+		data.RequiresAdmin = true
+	}
+
+	if op.ExternalDocs != nil {
+		desc := strings.TrimSpace(op.ExternalDocs.Description)
+		data.ExternalDocs.Description = strings.TrimSuffix(desc, ".")
+		data.ExternalDocs.URL = op.ExternalDocs.URL
+	}
+
+	data.SeeAlso = data.ExternalDocs.Description != "" && data.ExternalDocs.URL != ""
+
+	return data, nil
 }
 
 // writeOverviewData writes the API's overview data into an MDX file.

--- a/pkg/cmd/generate/openapi/openapi_test.go
+++ b/pkg/cmd/generate/openapi/openapi_test.go
@@ -7,6 +7,7 @@ import (
 	"text/template"
 
 	"github.com/algolia/docli/pkg/cmd/generate/utils"
+	"go.yaml.in/yaml/v4"
 )
 
 func TestGetAPIDataIncludesOperationDescriptionsInStubTemplate(t *testing.T) {
@@ -22,9 +23,9 @@ paths:
       operationId: getApiKey
       summary: Get an API key
       description: |
-        Retrieve an API key.
+        Retrieve the [API key](https://algolia.com) with **filters:active**.
 
-        Use this endpoint to fetch a key by its value.
+        Use this endpoint to fetch a key by its value with **sample** output.
       x-acl:
         - search
 `)
@@ -47,15 +48,21 @@ paths:
 		t.Fatalf("getAPIData() len = %d, want 1", len(data))
 	}
 
-	if got := data[0].ShortDescription; got != "Retrieve an API key." {
-		t.Fatalf("ShortDescription = %q, want %q", got, "Retrieve an API key.")
+	if got := data[0].ShortDescription; got != "Retrieve the API key with filters:active." {
+		t.Fatalf("ShortDescription = %q, want %q", got, "Retrieve the API key with filters:active.")
 	}
 
-	if got := data[0].Description; got != "Use this endpoint to fetch a key by its value." {
-		t.Fatalf("Description = %q, want %q", got, "Use this endpoint to fetch a key by its value.")
+	if got := data[0].Description; got != "Use this endpoint to fetch a key by its value with **sample** output." {
+		t.Fatalf(
+			"Description = %q, want %q",
+			got,
+			"Use this endpoint to fetch a key by its value with **sample** output.",
+		)
 	}
 
-	tmpl := template.Must(template.New("stub").Parse(stubTemplate))
+	tmpl := template.Must(template.New("stub").Funcs(template.FuncMap{
+		"frontmatterString": utils.QuoteFrontmatterString,
+	}).Parse(stubTemplate))
 
 	var got bytes.Buffer
 	if err := tmpl.Execute(&got, data[0]); err != nil {
@@ -64,14 +71,108 @@ paths:
 
 	rendered := got.String()
 
-	for _, want := range []string{
+	frontmatter := parseFrontmatter(t, rendered)
+	assertFrontmatterDescription(t, frontmatter, "Retrieve the API key with filters:active.")
+
+	assertRenderedContains(t, rendered, []string{
 		"title: Get an API key",
-		"description: Retrieve an API key.",
-		"Use this endpoint to fetch a key by its value.",
+		`description: "Retrieve the API key with filters:active."`,
+		"Use this endpoint to fetch a key by its value with **sample** output.",
 		"**Required ACL:** `search`",
-	} {
+	})
+}
+
+func TestGetAPIOverviewDataSplitsDescriptionWhenSummaryMissing(t *testing.T) {
+	t.Parallel()
+
+	spec := []byte(`openapi: 3.0.0
+info:
+  title: Search API
+  version: 1.0.0
+  description: |
+    Learn the [Search API](https://algolia.com) endpoints.
+
+    Use **filters** and _examples_ in the full overview.
+paths: {}
+`)
+
+	doc, err := utils.LoadSpec(spec)
+	if err != nil {
+		t.Fatalf("LoadSpec() error = %v", err)
+	}
+
+	data, err := getAPIOverviewData(doc, &Options{
+		APIName:         "search",
+		InputFileName:   "specs/search.yml",
+		OutputDirectory: "out",
+	})
+	if err != nil {
+		t.Fatalf("getAPIOverviewData() error = %v", err)
+	}
+
+	if got := data.ShortDescription; got != "Learn the Search API endpoints." {
+		t.Fatalf("ShortDescription = %q, want %q", got, "Learn the Search API endpoints.")
+	}
+
+	if got := data.Description; got != "Use **filters** and _examples_ in the full overview." {
+		t.Fatalf(
+			"Description = %q, want %q",
+			got,
+			"Use **filters** and _examples_ in the full overview.",
+		)
+	}
+
+	tmpl := template.Must(template.New("overview").Funcs(template.FuncMap{
+		"frontmatterString": utils.QuoteFrontmatterString,
+	}).Parse(overviewTemplate))
+
+	var rendered bytes.Buffer
+	if err := tmpl.Execute(&rendered, data); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	frontmatter := parseFrontmatter(t, rendered.String())
+	assertFrontmatterDescription(t, frontmatter, "Learn the Search API endpoints.")
+
+	assertRenderedContains(t, rendered.String(), []string{
+		"Use **filters** and _examples_ in the full overview.",
+	})
+}
+
+func parseFrontmatter(t *testing.T, rendered string) map[string]any {
+	t.Helper()
+
+	parts := strings.SplitN(rendered, "---\n", 3)
+	if len(parts) < 3 || parts[0] != "" {
+		t.Fatalf("rendered output missing frontmatter:\n%s", rendered)
+	}
+
+	frontmatter := strings.TrimSuffix(parts[1], "\n")
+
+	var parsed map[string]any
+
+	if err := yaml.Unmarshal([]byte(frontmatter), &parsed); err != nil {
+		t.Fatalf("yaml.Unmarshal() error = %v\nfrontmatter:\n%s", err, frontmatter)
+	}
+
+	return parsed
+}
+
+func assertFrontmatterDescription(t *testing.T, frontmatter map[string]any, want string) {
+	t.Helper()
+
+	gotDescription, ok := frontmatter["description"].(string)
+	if !ok || gotDescription != want {
+		t.Fatalf("frontmatter description = %#v, want %q", frontmatter["description"], want)
+	}
+}
+
+func assertRenderedContains(t *testing.T, rendered string, wants []string) {
+	t.Helper()
+
+	for _, want := range wants {
 		if !strings.Contains(rendered, want) {
-			t.Fatalf("rendered stub missing %q:\n%s", want, rendered)
+			t.Fatalf("rendered output missing %q:\n%s", want, rendered)
 		}
 	}
 }

--- a/pkg/cmd/generate/openapi/overview.mdx.tmpl
+++ b/pkg/cmd/generate/openapi/overview.mdx.tmpl
@@ -1,8 +1,10 @@
 ---
 title: {{ .Title }}
 sidebarTitle: Overview
-description: {{ .ShortDescription }}.
+description: {{ frontmatterString .ShortDescription }}
 public: true
 ---
+{{- if .Description }}
 
 {{ .Description }}
+{{- end }}

--- a/pkg/cmd/generate/openapi/stub.mdx.tmpl
+++ b/pkg/cmd/generate/openapi/stub.mdx.tmpl
@@ -1,6 +1,6 @@
 ---
 title: {{ .Title }}
-description: {{ .ShortDescription }}
+description: {{ frontmatterString .ShortDescription }}
 openapi: {{ .InputFilename }} {{ .Verb }} {{ .APIPath }}
 public: true
 ---

--- a/pkg/cmd/generate/utils/utils.go
+++ b/pkg/cmd/generate/utils/utils.go
@@ -13,6 +13,39 @@ import (
 	"go.yaml.in/yaml/v4"
 )
 
+var (
+	blankLinePattern           = regexp.MustCompile(`\n\s*\n+`)
+	htmlTagPattern             = regexp.MustCompile(`</?[^>]+>`)
+	markdownEscapePattern      = regexp.MustCompile(`\\([\\` + "`" + `*_{}\[\]()#+\-.!])`)
+	markdownImagePattern       = regexp.MustCompile(`!\[([^\]]*)\]\([^\)]+\)`)
+	markdownLinkPattern        = regexp.MustCompile(`\[([^\]]+)\]\([^\)]+\)`)
+	markdownReferencePattern   = regexp.MustCompile(`\[([^\]]+)\]\[[^\]]*\]`)
+	markdownShortcutRefPattern = regexp.MustCompile(`\[([^\]]+)\]\[\]`)
+	markdownAutoLinkPattern    = regexp.MustCompile(`<((?:https?|mailto):[^>]+)>`)
+	markdownCodePattern        = regexp.MustCompile("`([^`]*)`")
+	markdownStrongAsterisk     = regexp.MustCompile(`\*\*([^*\n]+)\*\*`)
+	markdownStrongUnderscore   = regexp.MustCompile(`__([^_\n]+)__`)
+	markdownEmAsterisk         = regexp.MustCompile(`\*([^*\n]+)\*`)
+	markdownEmUnderscore       = regexp.MustCompile(`_([^_\n]+)_`)
+	whitespacePattern          = regexp.MustCompile(`\s+`)
+)
+
+var sentenceAbbreviations = map[string]struct{}{
+	"dr.":   {},
+	"e.g.":  {},
+	"etc.":  {},
+	"i.e.":  {},
+	"jr.":   {},
+	"mr.":   {},
+	"mrs.":  {},
+	"ms.":   {},
+	"prof.": {},
+	"sr.":   {},
+	"u.k.":  {},
+	"u.s.":  {},
+	"vs.":   {},
+}
+
 // GetAPIName returns the name of the YAML file without extension as API name.
 func GetAPIName(path string) string {
 	// Have to make an exception for the Analytics API
@@ -125,31 +158,177 @@ func GetLanguageName(lang string) string {
 
 // SplitDescription splits a description into the first sentence and the rest.
 func SplitDescription(p string) (string, string) {
-	p = strings.TrimSpace(p)
-
-	// Split by empty line
-	parts := strings.SplitN(p, "\n\n", 2)
-	if len(parts) > 1 && strings.TrimSpace(parts[0]) != "" {
-		short := strings.TrimSpace(parts[0])
-		long := strings.TrimSpace(parts[1])
-
-		// No extra newline characters in between
-		short = strings.ReplaceAll(short, "\n", " ")
-
-		return short, long
+	p = normalizeDescriptionText(p)
+	if p == "" {
+		return "", ""
 	}
 
-	// No empty line: find first period
-	if idx := strings.Index(p, "."); idx != -1 {
-		short := strings.TrimSpace(p[:idx+1])
-		long := strings.TrimSpace(p[idx+1:])
+	if loc := blankLinePattern.FindStringIndex(p); loc != nil {
+		short := collapseInlineWhitespace(p[:loc[0]])
 
-		// No extra newline characters in between
-		short = strings.ReplaceAll(short, "\n", " ")
+		long := strings.TrimSpace(p[loc[1]:])
+
+		if short != "" {
+			return short, long
+		}
+	}
+
+	if idx := firstSentenceBoundary(p); idx != -1 {
+		short := collapseInlineWhitespace(p[:idx])
+		long := strings.TrimSpace(p[idx:])
 
 		return short, long
 	}
 
 	// No period: entire paragraph is the shortDescription
-	return p, ""
+	return collapseInlineWhitespace(p), ""
+}
+
+// StripMarkdown removes common inline Markdown formatting and collapses whitespace.
+func StripMarkdown(p string) string {
+	p = normalizeDescriptionText(p)
+	if p == "" {
+		return ""
+	}
+
+	stripped := markdownImagePattern.ReplaceAllString(p, `$1`)
+	stripped = markdownLinkPattern.ReplaceAllString(stripped, `$1`)
+	stripped = markdownReferencePattern.ReplaceAllString(stripped, `$1`)
+	stripped = markdownShortcutRefPattern.ReplaceAllString(stripped, `$1`)
+	stripped = markdownCodePattern.ReplaceAllString(stripped, `$1`)
+	stripped = markdownAutoLinkPattern.ReplaceAllString(stripped, `$1`)
+	stripped = htmlTagPattern.ReplaceAllString(stripped, "")
+
+	for {
+		next := stripped
+		next = markdownStrongAsterisk.ReplaceAllString(next, `$1`)
+		next = markdownStrongUnderscore.ReplaceAllString(next, `$1`)
+		next = markdownEmAsterisk.ReplaceAllString(next, `$1`)
+		next = markdownEmUnderscore.ReplaceAllString(next, `$1`)
+
+		if next == stripped {
+			break
+		}
+
+		stripped = next
+	}
+
+	stripped = markdownEscapePattern.ReplaceAllString(stripped, `$1`)
+
+	return collapseInlineWhitespace(stripped)
+}
+
+// QuoteFrontmatterString returns a double-quoted YAML string scalar.
+func QuoteFrontmatterString(p string) string {
+	escaped := strings.ReplaceAll(p, `\`, `\\`)
+	escaped = strings.ReplaceAll(escaped, `"`, `\"`)
+
+	return `"` + escaped + `"`
+}
+
+func normalizeDescriptionText(p string) string {
+	p = strings.ReplaceAll(p, "\r\n", "\n")
+	p = strings.ReplaceAll(p, "\r", "\n")
+
+	return strings.TrimSpace(p)
+}
+
+func collapseInlineWhitespace(p string) string {
+	return strings.TrimSpace(whitespacePattern.ReplaceAllString(p, " "))
+}
+
+func firstSentenceBoundary(p string) int {
+	for i := 0; i < len(p); i++ {
+		if boundary, ok := sentenceBoundaryAt(p, i); ok {
+			return boundary
+		}
+	}
+
+	return -1
+}
+
+func sentenceBoundaryAt(p string, idx int) (int, bool) {
+	if !isSentencePunctuation(p[idx]) {
+		return 0, false
+	}
+
+	if p[idx] == '.' && (isDecimalPoint(p, idx) || isAbbreviationBoundary(p, idx)) {
+		return 0, false
+	}
+
+	end := sentenceEndIndex(p, idx)
+	if end == len(p) {
+		return end, true
+	}
+
+	if !unicode.IsSpace(rune(p[end])) {
+		return 0, false
+	}
+
+	next := skipSentenceWhitespace(p, end)
+	if next == len(p) {
+		return end, true
+	}
+
+	if !isSentenceStart(rune(p[next])) {
+		return 0, false
+	}
+
+	return end, true
+}
+
+func sentenceEndIndex(p string, idx int) int {
+	end := idx + 1
+	for end < len(p) && isSentenceCloser(p[end]) {
+		end++
+	}
+
+	return end
+}
+
+func skipSentenceWhitespace(p string, idx int) int {
+	for idx < len(p) && unicode.IsSpace(rune(p[idx])) {
+		idx++
+	}
+
+	return idx
+}
+
+func isSentencePunctuation(b byte) bool {
+	return b == '.' || b == '!' || b == '?'
+}
+
+func isDecimalPoint(p string, idx int) bool {
+	if idx == 0 || idx == len(p)-1 {
+		return false
+	}
+
+	return unicode.IsDigit(rune(p[idx-1])) && unicode.IsDigit(rune(p[idx+1]))
+}
+
+func isAbbreviationBoundary(p string, idx int) bool {
+	start := idx
+	for start > 0 {
+		prev := rune(p[start-1])
+		if unicode.IsLetter(prev) || p[start-1] == '.' {
+			start--
+
+			continue
+		}
+
+		break
+	}
+
+	token := strings.ToLower(p[start : idx+1])
+	_, ok := sentenceAbbreviations[token]
+
+	return ok
+}
+
+func isSentenceCloser(b byte) bool {
+	return b == '"' || b == '\'' || b == ')' || b == ']' || b == '}'
+}
+
+func isSentenceStart(r rune) bool {
+	return unicode.IsUpper(r) || unicode.IsDigit(r) || r == '[' || r == '(' || r == '<' || r == '`'
 }

--- a/pkg/cmd/generate/utils/utils_test.go
+++ b/pkg/cmd/generate/utils/utils_test.go
@@ -264,6 +264,81 @@ func TestOutputFilename(t *testing.T) {
 	}
 }
 
+func TestSplitDescription(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantShort string
+		wantLong  string
+	}{
+		{
+			name:      "Split paragraphs with whitespace",
+			input:     "First paragraph.\n \nSecond paragraph.",
+			wantShort: "First paragraph.",
+			wantLong:  "Second paragraph.",
+		},
+		{
+			name:      "Split CRLF paragraphs",
+			input:     "First paragraph.\r\n\r\nSecond paragraph.",
+			wantShort: "First paragraph.",
+			wantLong:  "Second paragraph.",
+		},
+		{
+			name:      "Skip decimal point",
+			input:     "Version 3.14 is supported. Use it carefully.",
+			wantShort: "Version 3.14 is supported.",
+			wantLong:  "Use it carefully.",
+		},
+		{
+			name:      "Skip abbreviation",
+			input:     "Use e.g. filters. They narrow results.",
+			wantShort: "Use e.g. filters.",
+			wantLong:  "They narrow results.",
+		},
+		{
+			name:      "Keep entire text when no safe sentence boundary",
+			input:     "Use the API. then continue",
+			wantShort: "Use the API. then continue",
+			wantLong:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotShort, gotLong := SplitDescription(tt.input)
+			if gotShort != tt.wantShort || gotLong != tt.wantLong {
+				t.Fatalf(
+					"SplitDescription() = (%q, %q), want (%q, %q)",
+					gotShort,
+					gotLong,
+					tt.wantShort,
+					tt.wantLong,
+				)
+			}
+		})
+	}
+}
+
+func TestStripMarkdown(t *testing.T) {
+	input := "Use **bold** [links](https://algolia.com), _emphasis_, `code`, <em>HTML</em>, and <https://algolia.com>."
+	want := "Use bold links, emphasis, code, HTML, and https://algolia.com."
+
+	if got := StripMarkdown(input); got != want {
+		t.Fatalf("StripMarkdown() = %q, want %q", got, want)
+	}
+}
+
+func TestQuoteFrontmatterString(t *testing.T) {
+	input := `A "quoted" path C:\tmp: #tag`
+	want := `"A \"quoted\" path C:\\tmp: #tag"`
+
+	if got := QuoteFrontmatterString(input); got != want {
+		t.Fatalf("QuoteFrontmatterString() = %q, want %q", got, want)
+	}
+}
+
 func mockOp(extensions *yaml.Node) v3.Operation {
 	op := v3.Operation{}
 	op.Extensions = orderedmap.New[string, *yaml.Node]()


### PR DESCRIPTION
Some API descriptions have Markdown links or YAML-unsafe characters in them.
This PR improves the handling of such situations.