### PR TITLE
feat: generate supported LLMs snippets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 docli
 search.yml
+.env
 # Added by goreleaser init:
 dist/

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ See the individual subcommands to learn what content you can generate.
 
 **Aliases:** `gen`, `g`
 
-**Subcommands:** `cdn`, `clients`, `guides`, `openapi`, `sla`, `snippets`
+**Subcommands:** `cdn`, `clients`, `guides`, `openapi`, `sla`, `snippets`, `supported-llms`
 
 #### `docli generate cdn`
 
@@ -280,6 +280,55 @@ docli gen snippets specs/search-snippets.json -o openapi-snippets/search
 `-o, --output string`  Output directory for generated MDX files (default: `out`)
 
 `-q, --quiet`  Suppress non-error output
+
+`-v, --verbose`  Enable verbose output
+
+
+#### `docli generate supported-llms`
+
+```sh
+docli generate supported-llms [flags]
+```
+
+Generate snippets of supported LLMs per provider.
+
+This command fetches the supported LLMs per provider from the
+Agent Studio API and generates one MDX snippet file per provider,
+each listing the supported model IDs.
+
+The snippets are meant to be included in the hand-written
+LLM providers guide so the model lists stay up to date.
+A snippet is generated for the following providers:
+anthropic, openai, google_genai, and deepseek.
+azure_openai and openai_compatible are skipped because they
+don't have a fixed list of models.
+
+The Algolia credentials must be provided through the
+ALGOLIA_APPLICATION_ID and ALGOLIA_API_KEY environment variables,
+or through a .env file (default: .env) with those variables.
+Existing environment variables take precedence over the .env file.
+
+**Examples**
+
+```sh
+# Run from the root of algolia/docs-new
+ALGOLIA_APPLICATION_ID=… ALGOLIA_API_KEY=… \
+docli gen supported-llms -o snippets/agent-studio
+```
+
+**Flags**
+
+`--dry-run`  Preview actions without writing files
+
+`--env-file string`  Path to a .env file with the Algolia credentials (default: `.env`)
+
+`-h, --help`  Help for this command
+
+`-o, --output string`  Output directory for the generated snippet files (default: `.`)
+
+`-q, --quiet`  Suppress non-error output
+
+`--url string`  Override the API URL (defaults to the Agent Studio models endpoint)
 
 `-v, --verbose`  Enable verbose output
 

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.26
 
 require (
 	github.com/MakeNowJust/heredoc v1.0.0
+	github.com/joho/godotenv v1.5.1
 	github.com/pb33f/libopenapi v0.38.7
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,6 @@ github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
 github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
-github.com/buger/jsonparser v1.1.2 h1:frqHqw7otoVbk5M8LlE/L7HTnIq2v9RX6EJ48i9AxJk=
-github.com/buger/jsonparser v1.1.2/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/buger/jsonparser v1.2.0 h1:4EFcvK1kD4jyj6YqNK6skK6w+y7FHHBR+XBCtxwu/6g=
 github.com/buger/jsonparser v1.2.0/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
@@ -11,6 +9,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/pb33f/jsonpath v0.8.2 h1:Ou4C7zjYClBm97dfZjDCjdZGusJoynv/vrtiEKNfj2Y=
 github.com/pb33f/jsonpath v0.8.2/go.mod h1:zBV5LJW4OQOPatmQE2QdKpGQJvhDTlE5IEj6ASaRNTo=
 github.com/pb33f/libopenapi v0.38.7 h1:Q2jfgRPdnU38WW8wQvrX2HEPGiqsxj01PX1BHmAEihc=

--- a/pkg/cmd/generate/index.go
+++ b/pkg/cmd/generate/index.go
@@ -8,6 +8,7 @@ import (
 	"github.com/algolia/docli/pkg/cmd/generate/openapi"
 	"github.com/algolia/docli/pkg/cmd/generate/sla"
 	"github.com/algolia/docli/pkg/cmd/generate/snippets"
+	"github.com/algolia/docli/pkg/cmd/generate/supportedllms"
 	"github.com/spf13/cobra"
 )
 
@@ -35,6 +36,7 @@ func NewGenerateCmd() *cobra.Command {
 	command.AddCommand(snippets.NewSnippetsCommand())
 	command.AddCommand(guides.NewGuidesCommand())
 	command.AddCommand(cdn.NewCdnCommand())
+	command.AddCommand(supportedllms.NewCommand())
 
 	return command
 }

--- a/pkg/cmd/generate/supportedllms/supported_llms.go
+++ b/pkg/cmd/generate/supportedllms/supported_llms.go
@@ -6,13 +6,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
-	"net/url"
 	"os"
 	"path/filepath"
 	"sort"
-	"strings"
 	"time"
 
 	"github.com/MakeNowJust/heredoc"
@@ -117,18 +114,14 @@ func runCommand(ctx context.Context, opts *Options, printer *output.Printer) err
 		return err
 	}
 
-	requestURL := opts.URL
-	if requestURL == "" {
-		requestURL = fmt.Sprintf("https://%s.algolia.net%s", appID, modelsPath)
+	url := opts.URL
+	if url == "" {
+		url = fmt.Sprintf("https://%s.algolia.net%s", appID, modelsPath)
 	}
 
-	if err := validateRequestURL(requestURL); err != nil {
-		return err
-	}
+	printer.Infof("Fetching supported LLMs from: %s\n", url)
 
-	printer.Infof("Fetching supported LLMs from: %s\n", requestURL)
-
-	data, err := fetchModels(ctx, requestURL, appID, apiKey)
+	data, err := fetchModels(ctx, url, appID, apiKey)
 	if err != nil {
 		return fmt.Errorf("fetch supported LLMs: %w", err)
 	}
@@ -189,46 +182,9 @@ func validateOptions(opts *Options, appID, apiKey string) error {
 	return validate.OutputDir(opts.OutputDir, "output directory")
 }
 
-// validateRequestURL restricts requests to the known Agent Studio host to
-// guard against SSRF. Loopback addresses are allowed so the command can be
-// pointed at a local test server through --url.
-func validateRequestURL(raw string) error {
-	parsed, err := url.Parse(raw)
-	if err != nil {
-		return fmt.Errorf("invalid API URL %q: %w", raw, err)
-	}
-
-	if parsed.Scheme != "http" && parsed.Scheme != "https" {
-		return fmt.Errorf("API URL %q must use http or https", raw)
-	}
-
-	host := parsed.Hostname()
-
-	if host == "localhost" {
-		return nil
-	}
-
-	if ip := net.ParseIP(host); ip != nil && ip.IsLoopback() {
-		return nil
-	}
-
-	if parsed.Scheme != "https" {
-		return fmt.Errorf("API URL %q must use https", raw)
-	}
-
-	if host != "algolia.net" && !strings.HasSuffix(host, ".algolia.net") {
-		return fmt.Errorf("API URL host %q is not an algolia.net host", host)
-	}
-
-	return nil
-}
-
 // fetchModels requests the supported models per provider from the API.
-// The URL is validated by validateRequestURL before this call.
-func fetchModels(ctx context.Context, requestURL, appID, apiKey string) (ProviderModels, error) {
-	// #nosec G107 -- requestURL is validated by validateRequestURL and
-	// constrained to an algolia.net host (or loopback for tests).
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL, nil)
+func fetchModels(ctx context.Context, url, appID, apiKey string) (ProviderModels, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -245,7 +201,7 @@ func fetchModels(ctx context.Context, requestURL, appID, apiKey string) (Provide
 	defer res.Body.Close()
 
 	if res.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("request to %s failed with status %s", requestURL, res.Status)
+		return nil, fmt.Errorf("request to %s failed with status %s", url, res.Status)
 	}
 
 	var data ProviderModels

--- a/pkg/cmd/generate/supportedllms/supported_llms.go
+++ b/pkg/cmd/generate/supportedllms/supported_llms.go
@@ -1,0 +1,280 @@
+package supportedllms
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/algolia/docli/pkg/output"
+	"github.com/algolia/docli/pkg/validate"
+	"github.com/joho/godotenv"
+	"github.com/spf13/cobra"
+)
+
+const (
+	appIDEnv       = "ALGOLIA_APPLICATION_ID"
+	apiKeyEnv      = "ALGOLIA_API_KEY"
+	modelsPath     = "/agent-studio/1/providers/models"
+	defaultTimeout = 10 * time.Second
+)
+
+// generatedProviders lists the provider slugs for which a model snippet is
+// generated, in output order. Providers not listed here are skipped on purpose:
+// azure_openai documents "any deployed model" rather than a fixed list, and
+// openai_compatible has no fixed model list.
+var generatedProviders = []string{
+	"anthropic",
+	"openai",
+	"google_genai",
+	"deepseek",
+}
+
+// Options represents the options and flags for this command.
+type Options struct {
+	OutputDir string
+	URL       string
+	// EnvFile is the path to a .env file with the credentials.
+	EnvFile string
+	// EnvFileRequired is true when the user explicitly set --env-file,
+	// which turns a missing file into an error instead of a silent skip.
+	EnvFileRequired bool
+}
+
+// ProviderModels is the API response: provider slug to list of model IDs.
+type ProviderModels map[string][]string
+
+// NewCommand returns a new instance of the `generate supported-llms` command.
+func NewCommand() *cobra.Command {
+	opts := &Options{}
+
+	cmd := &cobra.Command{
+		Use:   "supported-llms",
+		Short: "Generate snippets of supported LLMs per provider",
+		Long: heredoc.Doc(`
+			This command fetches the supported LLMs per provider from the
+			Agent Studio API and generates one MDX snippet file per provider,
+			each listing the supported model IDs.
+
+			The snippets are meant to be included in the hand-written
+			LLM providers guide so the model lists stay up to date.
+			A snippet is generated for the following providers:
+			anthropic, openai, google_genai, and deepseek.
+			azure_openai and openai_compatible are skipped because they
+			don't have a fixed list of models.
+
+			The Algolia credentials must be provided through the
+			ALGOLIA_APPLICATION_ID and ALGOLIA_API_KEY environment variables,
+			or through a .env file (default: .env) with those variables.
+			Existing environment variables take precedence over the .env file.
+		`),
+		Example: heredoc.Doc(`
+			# Run from the root of algolia/docs-new
+			ALGOLIA_APPLICATION_ID=… ALGOLIA_API_KEY=… \
+			docli gen supported-llms -o snippets/agent-studio
+		`),
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			printer, err := output.New(cmd)
+			if err != nil {
+				return err
+			}
+
+			opts.EnvFileRequired = cmd.Flags().Changed("env-file")
+
+			return runCommand(cmd.Context(), opts, printer)
+		},
+	}
+
+	cmd.Flags().
+		StringVarP(&opts.OutputDir, "output", "o", ".", "Output directory for the generated snippet files")
+	cmd.Flags().
+		StringVar(&opts.URL, "url", "", "Override the API URL (defaults to the Agent Studio models endpoint)")
+	cmd.Flags().
+		StringVar(&opts.EnvFile, "env-file", ".env", "Path to a .env file with the Algolia credentials")
+
+	return cmd
+}
+
+func runCommand(ctx context.Context, opts *Options, printer *output.Printer) error {
+	if err := loadEnvFile(opts.EnvFile, opts.EnvFileRequired, printer); err != nil {
+		return err
+	}
+
+	appID := os.Getenv(appIDEnv)
+	apiKey := os.Getenv(apiKeyEnv)
+
+	if err := validateOptions(opts, appID, apiKey); err != nil {
+		return err
+	}
+
+	url := opts.URL
+	if url == "" {
+		url = fmt.Sprintf("https://%s.algolia.net%s", appID, modelsPath)
+	}
+
+	printer.Infof("Fetching supported LLMs from: %s\n", url)
+
+	data, err := fetchModels(ctx, url, appID, apiKey)
+	if err != nil {
+		return fmt.Errorf("fetch supported LLMs: %w", err)
+	}
+
+	warnUngeneratedProviders(data, printer)
+
+	if !printer.IsDryRun() {
+		if err = os.MkdirAll(opts.OutputDir, 0o700); err != nil {
+			return fmt.Errorf("create output directory %s: %w", opts.OutputDir, err)
+		}
+	}
+
+	for _, slug := range generatedProviders {
+		if err = writeSnippet(opts.OutputDir, slug, data[slug], printer); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// loadEnvFile loads credentials from a .env file into the environment.
+// Existing environment variables are not overridden. A missing file is only
+// an error when the user explicitly requested it with --env-file.
+func loadEnvFile(path string, required bool, printer *output.Printer) error {
+	if path == "" {
+		return nil
+	}
+
+	if _, err := os.Stat(path); err != nil {
+		if errors.Is(err, os.ErrNotExist) && !required {
+			printer.Verbosef("No .env file at %s, using environment variables\n", path)
+
+			return nil
+		}
+
+		return fmt.Errorf("read .env file %s: %w", path, err)
+	}
+
+	if err := godotenv.Load(path); err != nil {
+		return fmt.Errorf("load .env file %s: %w", path, err)
+	}
+
+	printer.Verbosef("Loaded credentials from %s\n", path)
+
+	return nil
+}
+
+func validateOptions(opts *Options, appID, apiKey string) error {
+	if appID == "" {
+		return fmt.Errorf("environment variable %s is required", appIDEnv)
+	}
+
+	if apiKey == "" {
+		return fmt.Errorf("environment variable %s is required", apiKeyEnv)
+	}
+
+	return validate.OutputDir(opts.OutputDir, "output directory")
+}
+
+// fetchModels requests the supported models per provider from the API.
+func fetchModels(ctx context.Context, url, appID, apiKey string) (ProviderModels, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("x-algolia-application-id", appID)
+	req.Header.Set("x-algolia-api-key", apiKey)
+
+	client := &http.Client{Timeout: defaultTimeout}
+
+	res, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("request to %s failed with status %s", url, res.Status)
+	}
+
+	var data ProviderModels
+	if err = json.NewDecoder(res.Body).Decode(&data); err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}
+
+// warnUngeneratedProviders logs any provider returned by the API that isn't in
+// the generated set, so a newly supported provider doesn't go unnoticed.
+func warnUngeneratedProviders(data ProviderModels, printer *output.Printer) {
+	generated := make(map[string]struct{}, len(generatedProviders))
+	for _, slug := range generatedProviders {
+		generated[slug] = struct{}{}
+	}
+
+	extra := make([]string, 0)
+
+	for slug, models := range data {
+		if _, ok := generated[slug]; ok {
+			continue
+		}
+
+		if len(models) == 0 {
+			continue
+		}
+
+		extra = append(extra, slug)
+	}
+
+	sort.Strings(extra)
+
+	for _, slug := range extra {
+		printer.Infof("Provider %q has models but no snippet is generated for it\n", slug)
+	}
+}
+
+// writeSnippet writes the model snippet for a single provider. Providers with
+// no models are skipped with a warning.
+func writeSnippet(
+	outputDir, slug string,
+	models []string,
+	printer *output.Printer,
+) error {
+	if len(models) == 0 {
+		printer.Infof("No models for provider %q, skipping snippet\n", slug)
+
+		return nil
+	}
+
+	out := filepath.Join(outputDir, slug+".mdx")
+
+	if err := printer.WriteFile(out, func(w io.Writer) error {
+		return renderSnippet(w, models)
+	}); err != nil {
+		return fmt.Errorf("write snippet for %s: %w", slug, err)
+	}
+
+	printer.Infof("Wrote %d models for %q to %s\n", len(models), slug, out)
+
+	return nil
+}
+
+// renderSnippet writes the model IDs as a Markdown bullet list of inline code
+// spans, preserving the order returned by the API.
+func renderSnippet(w io.Writer, models []string) error {
+	for _, model := range models {
+		if _, err := fmt.Fprintf(w, "- `%s`\n", model); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/cmd/generate/supportedllms/supported_llms.go
+++ b/pkg/cmd/generate/supportedllms/supported_llms.go
@@ -6,10 +6,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/MakeNowJust/heredoc"
@@ -114,14 +117,18 @@ func runCommand(ctx context.Context, opts *Options, printer *output.Printer) err
 		return err
 	}
 
-	url := opts.URL
-	if url == "" {
-		url = fmt.Sprintf("https://%s.algolia.net%s", appID, modelsPath)
+	requestURL := opts.URL
+	if requestURL == "" {
+		requestURL = fmt.Sprintf("https://%s.algolia.net%s", appID, modelsPath)
 	}
 
-	printer.Infof("Fetching supported LLMs from: %s\n", url)
+	if err := validateRequestURL(requestURL); err != nil {
+		return err
+	}
 
-	data, err := fetchModels(ctx, url, appID, apiKey)
+	printer.Infof("Fetching supported LLMs from: %s\n", requestURL)
+
+	data, err := fetchModels(ctx, requestURL, appID, apiKey)
 	if err != nil {
 		return fmt.Errorf("fetch supported LLMs: %w", err)
 	}
@@ -182,9 +189,46 @@ func validateOptions(opts *Options, appID, apiKey string) error {
 	return validate.OutputDir(opts.OutputDir, "output directory")
 }
 
+// validateRequestURL restricts requests to the known Agent Studio host to
+// guard against SSRF. Loopback addresses are allowed so the command can be
+// pointed at a local test server through --url.
+func validateRequestURL(raw string) error {
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("invalid API URL %q: %w", raw, err)
+	}
+
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return fmt.Errorf("API URL %q must use http or https", raw)
+	}
+
+	host := parsed.Hostname()
+
+	if host == "localhost" {
+		return nil
+	}
+
+	if ip := net.ParseIP(host); ip != nil && ip.IsLoopback() {
+		return nil
+	}
+
+	if parsed.Scheme != "https" {
+		return fmt.Errorf("API URL %q must use https", raw)
+	}
+
+	if host != "algolia.net" && !strings.HasSuffix(host, ".algolia.net") {
+		return fmt.Errorf("API URL host %q is not an algolia.net host", host)
+	}
+
+	return nil
+}
+
 // fetchModels requests the supported models per provider from the API.
-func fetchModels(ctx context.Context, url, appID, apiKey string) (ProviderModels, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+// The URL is validated by validateRequestURL before this call.
+func fetchModels(ctx context.Context, requestURL, appID, apiKey string) (ProviderModels, error) {
+	// #nosec G107 -- requestURL is validated by validateRequestURL and
+	// constrained to an algolia.net host (or loopback for tests).
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -201,7 +245,7 @@ func fetchModels(ctx context.Context, url, appID, apiKey string) (ProviderModels
 	defer res.Body.Close()
 
 	if res.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("request to %s failed with status %s", url, res.Status)
+		return nil, fmt.Errorf("request to %s failed with status %s", requestURL, res.Status)
 	}
 
 	var data ProviderModels

--- a/pkg/cmd/generate/supportedllms/supported_llms_test.go
+++ b/pkg/cmd/generate/supportedllms/supported_llms_test.go
@@ -81,7 +81,7 @@ func TestRunGeneratesExpectedSnippets(t *testing.T) {
 	}
 
 	for name, want := range wantFiles {
-		got, err := os.ReadFile(filepath.Join(dir, name))
+		got, err := os.ReadFile(filepath.Join(dir, filepath.Base(name)))
 		if err != nil {
 			t.Errorf("read %s: %v", name, err)
 
@@ -94,7 +94,7 @@ func TestRunGeneratesExpectedSnippets(t *testing.T) {
 	}
 
 	for _, name := range []string{"azure_openai.mdx", "openai_compatible.mdx"} {
-		if _, err := os.Stat(filepath.Join(dir, name)); !os.IsNotExist(err) {
+		if _, err := os.Stat(filepath.Join(dir, filepath.Base(name))); !os.IsNotExist(err) {
 			t.Errorf("expected %s not to be generated", name)
 		}
 	}
@@ -220,6 +220,32 @@ func TestLoadEnvFileMissing(t *testing.T) {
 
 	if err := loadEnvFile(missing, true, newTestPrinter(t)); err == nil {
 		t.Error("expected error for missing required env file")
+	}
+}
+
+func TestValidateRequestURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		url     string
+		wantErr bool
+	}{
+		{name: "algolia host", url: "https://APP.algolia.net/x", wantErr: false},
+		{name: "bare algolia host", url: "https://algolia.net/x", wantErr: false},
+		{name: "loopback ip", url: "http://127.0.0.1:8080/x", wantErr: false},
+		{name: "localhost", url: "http://localhost:8080/x", wantErr: false},
+		{name: "http to algolia rejected", url: "http://APP.algolia.net/x", wantErr: true},
+		{name: "foreign host rejected", url: "https://evil.example.com/x", wantErr: true},
+		{name: "suffix spoof rejected", url: "https://algolia.net.evil.com/x", wantErr: true},
+		{name: "non-http scheme rejected", url: "file:///etc/passwd", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateRequestURL(tt.url)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("validateRequestURL(%q) err = %v, wantErr %v", tt.url, err, tt.wantErr)
+			}
+		})
 	}
 }
 

--- a/pkg/cmd/generate/supportedllms/supported_llms_test.go
+++ b/pkg/cmd/generate/supportedllms/supported_llms_test.go
@@ -1,0 +1,267 @@
+package supportedllms
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/algolia/docli/pkg/output"
+	"github.com/spf13/cobra"
+)
+
+// newTestPrinter builds a printer backed by discard buffers for tests.
+func newTestPrinter(t *testing.T) *output.Printer {
+	t.Helper()
+
+	cmd := &cobra.Command{}
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.Flags().BoolP(output.FlagVerbose, "v", false, "verbose")
+	cmd.Flags().BoolP(output.FlagQuiet, "q", false, "quiet")
+	cmd.Flags().Bool(output.FlagDryRun, false, "dry run")
+
+	printer, err := output.New(cmd)
+	if err != nil {
+		t.Fatalf("new printer: %v", err)
+	}
+
+	return printer
+}
+
+func TestRenderSnippet(t *testing.T) {
+	var sb bytes.Buffer
+
+	// Order must be preserved verbatim, suffixes kept.
+	models := []string{"claude-fable-5", "claude-opus-4-8", "claude-sonnet-4-5-20250929"}
+	if err := renderSnippet(&sb, models); err != nil {
+		t.Fatalf("renderSnippet: %v", err)
+	}
+
+	want := "- `claude-fable-5`\n- `claude-opus-4-8`\n- `claude-sonnet-4-5-20250929`\n"
+	if got := sb.String(); got != want {
+		t.Fatalf("renderSnippet:\n got %q\nwant %q", got, want)
+	}
+}
+
+func TestRunGeneratesExpectedSnippets(t *testing.T) {
+	body := `{
+		"anthropic": ["claude-opus-4-8", "claude-sonnet-5"],
+		"openai": ["gpt-5.6", "gpt-4.1"],
+		"google_genai": ["gemini-3.5-flash"],
+		"deepseek": ["deepseek-chat"],
+		"azure_openai": ["gpt-5", "gpt-4.1"],
+		"openai_compatible": []
+	}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+	defer server.Close()
+
+	dir := t.TempDir()
+	t.Setenv(appIDEnv, "app")
+	t.Setenv(apiKeyEnv, "key")
+
+	opts := &Options{OutputDir: dir, URL: server.URL}
+	if err := runCommand(context.Background(), opts, newTestPrinter(t)); err != nil {
+		t.Fatalf("runCommand: %v", err)
+	}
+
+	// deepseek is generated; azure_openai and openai_compatible are not.
+	wantFiles := map[string]string{
+		"anthropic.mdx":    "- `claude-opus-4-8`\n- `claude-sonnet-5`\n",
+		"openai.mdx":       "- `gpt-5.6`\n- `gpt-4.1`\n",
+		"google_genai.mdx": "- `gemini-3.5-flash`\n",
+		"deepseek.mdx":     "- `deepseek-chat`\n",
+	}
+
+	for name, want := range wantFiles {
+		got, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			t.Errorf("read %s: %v", name, err)
+
+			continue
+		}
+
+		if string(got) != want {
+			t.Errorf("%s:\n got %q\nwant %q", name, string(got), want)
+		}
+	}
+
+	for _, name := range []string{"azure_openai.mdx", "openai_compatible.mdx"} {
+		if _, err := os.Stat(filepath.Join(dir, name)); !os.IsNotExist(err) {
+			t.Errorf("expected %s not to be generated", name)
+		}
+	}
+}
+
+func TestRunDryRunWritesNothing(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"anthropic":["claude-opus-4-8"]}`))
+	}))
+	defer server.Close()
+
+	dir := filepath.Join(t.TempDir(), "out")
+	t.Setenv(appIDEnv, "app")
+	t.Setenv(apiKeyEnv, "key")
+
+	cmd := &cobra.Command{}
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.Flags().BoolP(output.FlagVerbose, "v", false, "verbose")
+	cmd.Flags().BoolP(output.FlagQuiet, "q", false, "quiet")
+	cmd.Flags().Bool(output.FlagDryRun, false, "dry run")
+
+	if err := cmd.Flags().Set(output.FlagDryRun, "true"); err != nil {
+		t.Fatalf("set dry run: %v", err)
+	}
+
+	printer, err := output.New(cmd)
+	if err != nil {
+		t.Fatalf("new printer: %v", err)
+	}
+
+	opts := &Options{OutputDir: dir, URL: server.URL}
+	if err := runCommand(context.Background(), opts, printer); err != nil {
+		t.Fatalf("runCommand: %v", err)
+	}
+
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Errorf("dry run should not create output directory")
+	}
+}
+
+func TestValidateOptions(t *testing.T) {
+	tests := []struct {
+		name    string
+		appID   string
+		apiKey  string
+		wantErr bool
+	}{
+		{name: "both set", appID: "app", apiKey: "key", wantErr: false},
+		{name: "missing app id", appID: "", apiKey: "key", wantErr: true},
+		{name: "missing api key", appID: "app", apiKey: "", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateOptions(&Options{OutputDir: t.TempDir()}, tt.appID, tt.apiKey)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("validateOptions err = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestLoadEnvFile(t *testing.T) {
+	dir := t.TempDir()
+	envPath := filepath.Join(dir, ".env")
+
+	if err := os.WriteFile(
+		envPath,
+		[]byte("ALGOLIA_APPLICATION_ID=from-file\nALGOLIA_API_KEY=key-from-file\n"),
+		0o600,
+	); err != nil {
+		t.Fatalf("write env file: %v", err)
+	}
+
+	t.Setenv(appIDEnv, "")
+	t.Setenv(apiKeyEnv, "")
+	os.Unsetenv(appIDEnv)
+	os.Unsetenv(apiKeyEnv)
+
+	if err := loadEnvFile(envPath, true, newTestPrinter(t)); err != nil {
+		t.Fatalf("loadEnvFile: %v", err)
+	}
+
+	if got := os.Getenv(appIDEnv); got != "from-file" {
+		t.Errorf("%s = %q, want from-file", appIDEnv, got)
+	}
+
+	if got := os.Getenv(apiKeyEnv); got != "key-from-file" {
+		t.Errorf("%s = %q, want key-from-file", apiKeyEnv, got)
+	}
+}
+
+func TestLoadEnvFileEnvTakesPrecedence(t *testing.T) {
+	dir := t.TempDir()
+	envPath := filepath.Join(dir, ".env")
+
+	if err := os.WriteFile(
+		envPath,
+		[]byte("ALGOLIA_APPLICATION_ID=from-file\n"),
+		0o600,
+	); err != nil {
+		t.Fatalf("write env file: %v", err)
+	}
+
+	t.Setenv(appIDEnv, "from-env")
+
+	if err := loadEnvFile(envPath, true, newTestPrinter(t)); err != nil {
+		t.Fatalf("loadEnvFile: %v", err)
+	}
+
+	if got := os.Getenv(appIDEnv); got != "from-env" {
+		t.Errorf("%s = %q, want from-env (env must win over .env)", appIDEnv, got)
+	}
+}
+
+func TestLoadEnvFileMissing(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist.env")
+
+	if err := loadEnvFile(missing, false, newTestPrinter(t)); err != nil {
+		t.Errorf("expected no error for missing optional env file, got %v", err)
+	}
+
+	if err := loadEnvFile(missing, true, newTestPrinter(t)); err == nil {
+		t.Error("expected error for missing required env file")
+	}
+}
+
+func TestFetchModels(t *testing.T) {
+	const (
+		appID  = "test-app"
+		apiKey = "test-key"
+	)
+
+	var gotAppID, gotAPIKey string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAppID = r.Header.Get("x-algolia-application-id")
+		gotAPIKey = r.Header.Get("x-algolia-api-key")
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"openai":["gpt-4"],"anthropic":["claude-opus-4-8"]}`))
+	}))
+	defer server.Close()
+
+	data, err := fetchModels(context.Background(), server.URL, appID, apiKey)
+	if err != nil {
+		t.Fatalf("fetchModels: %v", err)
+	}
+
+	if gotAppID != appID || gotAPIKey != apiKey {
+		t.Fatalf("headers not forwarded: appID=%q apiKey=%q", gotAppID, gotAPIKey)
+	}
+
+	if !reflect.DeepEqual(data["openai"], []string{"gpt-4"}) {
+		t.Fatalf("unexpected data: %+v", data)
+	}
+}
+
+func TestFetchModelsNon200(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	_, err := fetchModels(context.Background(), server.URL, "app", "key")
+	if err == nil {
+		t.Fatal("expected error on non-200 response")
+	}
+}

--- a/pkg/cmd/generate/supportedllms/supported_llms_test.go
+++ b/pkg/cmd/generate/supportedllms/supported_llms_test.go
@@ -81,7 +81,7 @@ func TestRunGeneratesExpectedSnippets(t *testing.T) {
 	}
 
 	for name, want := range wantFiles {
-		got, err := os.ReadFile(filepath.Join(dir, filepath.Base(name)))
+		got, err := os.ReadFile(filepath.Join(dir, name))
 		if err != nil {
 			t.Errorf("read %s: %v", name, err)
 
@@ -94,7 +94,7 @@ func TestRunGeneratesExpectedSnippets(t *testing.T) {
 	}
 
 	for _, name := range []string{"azure_openai.mdx", "openai_compatible.mdx"} {
-		if _, err := os.Stat(filepath.Join(dir, filepath.Base(name))); !os.IsNotExist(err) {
+		if _, err := os.Stat(filepath.Join(dir, name)); !os.IsNotExist(err) {
 			t.Errorf("expected %s not to be generated", name)
 		}
 	}
@@ -220,32 +220,6 @@ func TestLoadEnvFileMissing(t *testing.T) {
 
 	if err := loadEnvFile(missing, true, newTestPrinter(t)); err == nil {
 		t.Error("expected error for missing required env file")
-	}
-}
-
-func TestValidateRequestURL(t *testing.T) {
-	tests := []struct {
-		name    string
-		url     string
-		wantErr bool
-	}{
-		{name: "algolia host", url: "https://APP.algolia.net/x", wantErr: false},
-		{name: "bare algolia host", url: "https://algolia.net/x", wantErr: false},
-		{name: "loopback ip", url: "http://127.0.0.1:8080/x", wantErr: false},
-		{name: "localhost", url: "http://localhost:8080/x", wantErr: false},
-		{name: "http to algolia rejected", url: "http://APP.algolia.net/x", wantErr: true},
-		{name: "foreign host rejected", url: "https://evil.example.com/x", wantErr: true},
-		{name: "suffix spoof rejected", url: "https://algolia.net.evil.com/x", wantErr: true},
-		{name: "non-http scheme rejected", url: "file:///etc/passwd", wantErr: true},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := validateRequestURL(tt.url)
-			if (err != nil) != tt.wantErr {
-				t.Fatalf("validateRequestURL(%q) err = %v, wantErr %v", tt.url, err, tt.wantErr)
-			}
-		})
 	}
 }
 


### PR DESCRIPTION
Grab the list of supported LLM providers and models from the Agent Studio API and print them as MDX snippets.